### PR TITLE
Fixed "Illegal offset type in isset or empty"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.3.1 (2015-10-21)
+
+### Added
+
+* Nothing
+
+### Deprecated
+
+* Nothing
+
+### Removed
+
+* Nothing
+
+### Fixed
+
+* Fixed *Illegal offset type in isset or empty* if options are empty and recursive mandatory options are used
+
 ## 0.3.0 (2015-10-18)
 
 ### Added

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -149,12 +149,13 @@ trait ConfigurationTrait
     private function checkMandatoryOptions($mandatoryOptions, $options)
     {
         foreach ($mandatoryOptions as $key => $mandatoryOption) {
-            # if a string key exists it indicates a recursive check
-            if (isset($options[$key])) {
+            $useRecursion = !is_scalar($mandatoryOption);
+
+            if ($useRecursion && isset($options[$key])) {
                 $this->checkMandatoryOptions($mandatoryOption, $options[$key]);
                 return;
             }
-            if (isset($options[$mandatoryOption])) {
+            if (!$useRecursion && isset($options[$mandatoryOption])) {
                 continue;
             }
             $id = null;
@@ -165,7 +166,7 @@ trait ConfigurationTrait
 
             throw new Exception\MandatoryOptionNotFoundException(sprintf(
                 'Mandatory option "%s" was not set for configuration "' . "['%s']['%s']%s",
-                $mandatoryOption,
+                $useRecursion ? $key : $mandatoryOption,
                 $this->vendorName(),
                 $this->packageName(),
                 $id ? '["' . $id . '""]' : ''

--- a/test/ConfigurationTraitTest.php
+++ b/test/ConfigurationTraitTest.php
@@ -355,6 +355,25 @@ class ConfigurationTraitTest extends TestCase
     }
 
     /**
+     * Tests if options() throws a runtime exception if a recursive mandatory option is missing
+     *
+     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     */
+    public function testOptionsThrowsMandatoryOptionNotFoundExceptionIfOptionsAreEmpty()
+    {
+        $stub = new ConnectionMandatoryRecursiveContainerIdConfiguration();
+
+        $config = ['doctrine' => ['connection' => ['orm_default' => []]]];
+
+        $this->setExpectedException(
+            'Interop\Config\Exception\MandatoryOptionNotFoundException',
+            'Mandatory option "params"'
+        );
+
+        $stub->options($config);
+    }
+
+    /**
      * Returns test config
      *
      * @return array

--- a/test/TestAsset/ConnectionMandatoryRecursiveContainerIdConfiguration.php
+++ b/test/TestAsset/ConnectionMandatoryRecursiveContainerIdConfiguration.php
@@ -36,6 +36,6 @@ class ConnectionMandatoryRecursiveContainerIdConfiguration implements
 
     public function mandatoryOptions()
     {
-        return ['driverClass', 'params' => ['user', 'dbname']];
+        return ['params' => ['user', 'dbname'], 'driverClass'];
     }
 }


### PR DESCRIPTION
Fixed "Illegal offset type in isset or empty" if options are empty and recursive mandatory options are used
