### PR TITLE
Refactored benchmark cases

### DIFF
--- a/benchmark/BaseCase.php
+++ b/benchmark/BaseCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace InteropBench\Config;
+
+/**
+ * @BeforeMethods({"classSetUp"})
+ * @Revs(10000)
+ * @Iterations(10)
+ */
+abstract class BaseCase
+{
+    public function classSetUp()
+    {
+    }
+}

--- a/benchmark/ProvidesDefaultOptionsBench.php
+++ b/benchmark/ProvidesDefaultOptionsBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionDefaultOptionsConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class ProvidesDefaultOptions
+class ProvidesDefaultOptions extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class ProvidesDefaultOptions
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function benchOptions()
     {

--- a/benchmark/RequiresConfigBench.php
+++ b/benchmark/RequiresConfigBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class RequiresConfigBench
+class RequiresConfigBench extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class RequiresConfigBench
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function benchOptions()
     {

--- a/benchmark/RequiresContainerIdBench.php
+++ b/benchmark/RequiresContainerIdBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionContainerIdConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class RequiresContainerId
+class RequiresContainerId extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class RequiresContainerId
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function benchOptions()
     {

--- a/benchmark/RequiresMandatoryOptionsBench.php
+++ b/benchmark/RequiresMandatoryOptionsBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionMandatoryConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class RequiresMandatoryOptions
+class RequiresMandatoryOptions extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class RequiresMandatoryOptions
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function benchOptions()
     {

--- a/benchmark/RequiresMandatoryOptionsContainerIdBench.php
+++ b/benchmark/RequiresMandatoryOptionsContainerIdBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionMandatoryContainerIdConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class RequiresMandatoryOptionsContainerId
+class RequiresMandatoryOptionsContainerId extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class RequiresMandatoryOptionsContainerId
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function benchOptions()
     {

--- a/benchmark/RequiresMandatoryOptionsRecursiveContainerIdBench.php
+++ b/benchmark/RequiresMandatoryOptionsRecursiveContainerIdBench.php
@@ -11,10 +11,7 @@ namespace InteropBench\Config;
 
 use InteropTest\Config\TestAsset\ConnectionMandatoryRecursiveContainerIdConfiguration;
 
-/**
- * @BeforeMethods({"classSetUp"})
- */
-class RequiresMandatoryOptionsRecursiveContainerId
+class RequiresMandatoryOptionsRecursiveContainerId extends BaseCase
 {
     private $config;
 
@@ -31,9 +28,6 @@ class RequiresMandatoryOptionsRecursiveContainerId
 
     /**
      * Retrieve options
-     *
-     * @Revs(10000)
-     * @Iterations(10)
      */
     public function options()
     {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "phpunit/phpunit": "~4.8",
     "phpunit/php-invoker": "~1.1",
     "squizlabs/php_codesniffer": "~2.3",
-    "phpbench/phpbench": "^0.5",
+    "phpbench/phpbench": "dev-master",
     "tobiju/bookdown-bootswatch-templates": "1.0.x-dev"
   },
   "minimum-stability": "dev",

--- a/phpbench.json.dist
+++ b/phpbench.json.dist
@@ -1,4 +1,5 @@
 {
   "bootstrap": "vendor/autoload.php",
-  "path": "benchmark"
+  "path": "benchmark",
+  "retry_threshold": 4
 }


### PR DESCRIPTION
This PR refactors the PHPBench setup by having the becnhmarks extend a single base class, and so the methods inherit the same `@BeforeMethods`, `@Revs` and `@Iterations`.

Note that this actually requires a bug fix that is only in `dev-master` of PHPBench, so better not to merge this until the 0.7 release.
