### PR TITLE
[RFC] Rename accessor names.

### DIFF
--- a/src/RequiresConfig.php
+++ b/src/RequiresConfig.php
@@ -30,7 +30,7 @@ interface RequiresConfig
      *
      * @return array|ArrayAccess
      */
-    public function dimensions();
+    public function getDimensions();
 
     /**
      * Returns options based on dimensions() like [vendor][package] and can perform mandatory option checks if
@@ -64,7 +64,7 @@ interface RequiresConfig
      * @throws Exception\OptionNotFoundException If no options are available
      * @throws Exception\MandatoryOptionNotFoundException If a mandatory option is missing
      */
-    public function options($config);
+    public function getOptions($config);
 
     /**
      * Checks if options are available depending on implemented interfaces and checks that the retrieved options are an


### PR DESCRIPTION
This is not BC by a long shot, but I believe the current interface names are awkward.
### The change
- instead of function `dimensions()` it should be function `getDimensions()`
- instead of function `options()` it should be function `getOptions()`
### Reasoning

Dimensions and options are values on the config (value) object, hence retrieving them via methods is accessing; those methods are called accessors. A common practice is for accessors to be aptly named to recognize their function by prefixing `get` or `set` accordingly.

Assuming the (config) class contains multiple action methods such as `merge()` `performAction()` or even `setOptions()` (i.e. a mutable config) then the interop interface should hint getters with names that describe their purpose: `getOptions()` and `getDimensions()`. This makes them less ambiguous and more in line with other libraries and practices.
