### PR TITLE
fix inconsistency on defaultOptions return type,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.0.1 (2016-12-09)
+This release contains **no** BC break.
+
+### Added
+
+* More test cases for iterable return type and `\Iterator` objects
+
+### Deprecated
+
+* Nothing
+
+### Removed
+
+* Nothing
+
+### Fixed
+
+* [#34](https://github.com/sandrokeil/interop-config/issue/34): Inconsistent return type in `defaultOptions()`
+  * `defaultOptions()` method return type is `iterable` but `array` is still valid
+
+
 ## 2.0.0 (2016-12-06)
 To upgrade from version 1.x to version 2.x you have to add the PHP scalar types of the interfaces to your implemented 
 factory methods.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You should have coding conventions and you should have config conventions. If no
 
 ## Installation
 
-Installation of this module uses composer. For composer documentation, please refer to
+The suggested installation method is via composer. For composer documentation, please refer to
 [getcomposer.org](http://getcomposer.org/).
 
 Run `composer require sandrokeil/interop-config` to install interop-config. Version `1.x` is for PHP < 7.1 and Version `2.x` is for PHP >= 7.1.

--- a/doc/book/intro.md
+++ b/doc/book/intro.md
@@ -36,7 +36,7 @@ You should have coding conventions and you should have config conventions. If no
 `interop-config` is universally applicable! See further documentation for more details.
 
 ## Installation
-Installation of this library uses Composer. For Composer documentation, please refer to
+The suggested installation method is via composer. For composer documentation, please refer to
 [getcomposer.org](http://getcomposer.org/).
 
 Run `composer require sandrokeil/interop-config` to install interop-config.

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -39,14 +39,14 @@ class MyAwesomeFactory implements RequiresConfigId
     public function dimensions() : iterable
     {
         return ['vendor-package'];
-    }
-    
-    public function canRetrieveOptions($config, $configId = null) : bool
+    } 
+
+    public function canRetrieveOptions($config, string $configId = null) : bool
     {
         // custom implementation depending on specifications
     }
     
-    public function options($config, $configId = null)
+    public function options($config, string $configId = null)
     {
         // custom implementation depending on specifications
     }

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -1,5 +1,5 @@
 {
-  "title": "interop-config",
+  "title": "interop-config - configurable factories",
   "content": [
     {"getting-started": "book/getting-started/bookdown.json"},
     {"reference": "book/reference/bookdown.json"},
@@ -8,5 +8,5 @@
   "target": "./html",
   "tocDepth": 2,
   "template": "../vendor/tobiju/bookdown-bootswatch-templates/templates/main.php",
-  "copyright": "Copyright (c) 2015-2016 <a href=\"https://sandro-keil.de/\" title=\"I write about topics, advices and trends of web development\">Sandro Keil</a> <br/> Powered by <a href=\"https://github.com/tobiju/bookdown-bootswatch-templates\" title=\"Visit project to generate your own docs\">Bookdown Bootswatch Templates</a>"
+  "copyright": "Visit interop-config on <a href=\"https://github.com/sandrokeil/interop-config\" title=\"interop-config on GitHub\">GitHub</a><br/>Copyright (c) 2015-2016 <a href=\"https://sandro-keil.de/\" title=\"I write about topics, advices and trends of web development\">Sandro Keil</a> <br/> Powered by <a href=\"https://github.com/tobiju/bookdown-bootswatch-templates\" title=\"Visit project to generate your own docs\">Bookdown Bootswatch Templates</a>"
 }

--- a/src/ConfigurationTrait.php
+++ b/src/ConfigurationTrait.php
@@ -13,6 +13,7 @@ namespace Interop\Config;
 
 use ArrayAccess;
 use Interop\Config\Exception;
+use Iterator;
 
 /**
  * ConfigurationTrait which retrieves options from configuration, see interface \Interop\Config\RequiresConfig
@@ -42,6 +43,7 @@ trait ConfigurationTrait
     public function canRetrieveOptions($config, string $configId = null): bool
     {
         $dimensions = $this->dimensions();
+        $dimensions = $dimensions instanceof Iterator ? iterator_to_array($dimensions) : $dimensions;
 
         if ($this instanceof RequiresConfigId) {
             $dimensions[] = $configId;
@@ -82,6 +84,7 @@ trait ConfigurationTrait
     public function options($config, string $configId = null)
     {
         $dimensions = $this->dimensions();
+        $dimensions = $dimensions instanceof Iterator ? iterator_to_array($dimensions) : $dimensions;
 
         if ($this instanceof RequiresConfigId) {
             $dimensions[] = $configId;
@@ -115,7 +118,12 @@ trait ConfigurationTrait
         }
 
         if ($this instanceof ProvidesDefaultOptions) {
-            $config = array_replace_recursive($this->defaultOptions(), $config);
+            $options = $this->defaultOptions();
+
+            $config = array_replace_recursive(
+                $options instanceof Iterator ? iterator_to_array($options) : (array)$options,
+                (array)$config
+            );
         }
         return $config;
     }

--- a/src/ProvidesDefaultOptions.php
+++ b/src/ProvidesDefaultOptions.php
@@ -22,7 +22,7 @@ interface ProvidesDefaultOptions
     /**
      * Returns a list of default options, which are merged in \Interop\Config\RequiresConfig::options()
      *
-     * @return mixed[] List with default options and values, can be nested
+     * @return iterable List with default options and values, can be nested
      */
-    public function defaultOptions(): array;
+    public function defaultOptions(): iterable;
 }

--- a/test/ConfigurationTraitTest.php
+++ b/test/ConfigurationTraitTest.php
@@ -17,6 +17,7 @@ use Interop\Config\Exception\OptionNotFoundException;
 use Interop\Config\Exception\UnexpectedValueException;
 use InteropTest\Config\TestAsset\ConnectionConfiguration;
 use InteropTest\Config\TestAsset\ConnectionContainerIdConfiguration;
+use InteropTest\Config\TestAsset\ConnectionDefaultOptionsConfiguration;
 use InteropTest\Config\TestAsset\ConnectionDefaultOptionsMandatoryContainetIdConfiguration;
 use InteropTest\Config\TestAsset\ConnectionMandatoryConfiguration;
 use InteropTest\Config\TestAsset\ConnectionMandatoryContainerIdConfiguration;
@@ -26,6 +27,7 @@ use InteropTest\Config\TestAsset\FlexibleConfiguration;
 use InteropTest\Config\TestAsset\PackageDefaultAndMandatoryOptionsConfiguration;
 use InteropTest\Config\TestAsset\PackageDefaultOptionsConfiguration;
 use InteropTest\Config\TestAsset\PlainConfiguration;
+use InteropTest\Config\TestAsset\UniversalContainerIdConfiguration;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -136,9 +138,9 @@ class ConfigurationTraitTest extends TestCase
      * Tests options() should throw exception if config id is missing but RequiresConfigId interface is implemented
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\Exception\OptionNotFoundException::missingOptions
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\Exception\OptionNotFoundException::missingOptions
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsThrowsOptionNotFoundExceptionIfConfigIdIsMissingWithRequiresConfigId($config): void
     {
@@ -275,8 +277,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with container id
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsReturnsDataWithContainerId($config): void
     {
@@ -294,8 +296,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works without container id
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsReturnsData($config): void
     {
@@ -312,8 +314,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with flexible dimensions
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsReturnsDataWithFlexibleDimensions($config): void
     {
@@ -331,8 +333,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with no dimensions
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsReturnsDataWithNoDimensions($config): void
     {
@@ -350,8 +352,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with default options
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsReturnsDataWithDefaultOptions($config): void
     {
@@ -364,6 +366,7 @@ class ConfigurationTraitTest extends TestCase
         $options = $stub->options($config, 'orm_default');
         $defaultOptions = $stub->defaultOptions();
 
+        self::assertCount(2, $options);
         self::assertArrayHasKey('params', $options);
         self::assertSame($options['params']['host'], $defaultOptions['params']['host']);
         self::assertSame($options['params']['port'], $defaultOptions['params']['port']);
@@ -380,6 +383,7 @@ class ConfigurationTraitTest extends TestCase
         self::assertTrue($stub->canRetrieveOptions($config, 'orm_default'));
         $options = $stub->options($config, 'orm_default');
 
+        self::assertCount(2, $options);
         self::assertArrayHasKey('params', $options);
         self::assertSame($options['params']['host'], $defaultOptions['params']['host']);
         self::assertSame($options['params']['port'], $defaultOptions['params']['port']);
@@ -404,6 +408,7 @@ class ConfigurationTraitTest extends TestCase
 
         $options = $stub->options([]);
 
+        self::assertCount(2, $options);
         self::assertSame($expected, $options);
     }
 
@@ -411,8 +416,8 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works default options and default options not override provided options
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsThatDefaultOptionsNotOverrideProvidedOptions($config): void
     {
@@ -421,6 +426,7 @@ class ConfigurationTraitTest extends TestCase
         self::assertTrue($stub->canRetrieveOptions($config, 'orm_default'));
         $options = $stub->options($config, 'orm_default');
 
+        self::assertCount(2, $options);
         self::assertArrayHasKey('params', $options);
         self::assertSame(
             $options['params']['host'],
@@ -440,9 +446,9 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with mandatory options interface
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsChecksMandatoryOptions($config): void
     {
@@ -451,6 +457,7 @@ class ConfigurationTraitTest extends TestCase
         self::assertTrue($stub->canRetrieveOptions($config));
         $options = $stub->options($config);
 
+        self::assertCount(1, $options);
         self::assertArrayHasKey('orm_default', $options);
     }
 
@@ -458,9 +465,9 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() works with mandatory options interface
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsChecksMandatoryOptionsWithContainerId($config): void
     {
@@ -469,6 +476,7 @@ class ConfigurationTraitTest extends TestCase
         self::assertTrue($stub->canRetrieveOptions($config, 'orm_default'));
         $options = $stub->options($config, 'orm_default');
 
+        self::assertCount(2, $options);
         self::assertArrayHasKey('driverClass', $options);
         self::assertArrayHasKey('params', $options);
     }
@@ -477,10 +485,10 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() throws a runtime exception if mandatory option is missing
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\Exception\MandatoryOptionNotFoundException::missingOption
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\Exception\MandatoryOptionNotFoundException::missingOption
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsThrowsMandatoryOptionNotFoundExceptionIfMandatoryOptionIsMissing($config): void
     {
@@ -498,10 +506,10 @@ class ConfigurationTraitTest extends TestCase
      * Tests if options() throws a runtime exception if a recursive mandatory option is missing
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\Exception\MandatoryOptionNotFoundException::missingOption
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\Exception\MandatoryOptionNotFoundException::missingOption
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsThrowsMandatoryOptionNotFoundExceptionIfMandatoryOptionRecursiveIsMissing($config): void
     {
@@ -519,9 +527,9 @@ class ConfigurationTraitTest extends TestCase
      * Tests options() with recursive mandatory options check
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsWithRecursiveMandatoryOptionCheck($config): void
     {
@@ -535,9 +543,9 @@ class ConfigurationTraitTest extends TestCase
      * Tests options() with recursive mandatory options as array iterator
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::options
-     * @covers \Interop\Config\ConfigurationTrait::checkMandatoryOptions
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::checkMandatoryOptions
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsWithRecursiveArrayIteratorMandatoryOptionCheck($config): void
     {
@@ -548,11 +556,11 @@ class ConfigurationTraitTest extends TestCase
     }
 
     /**
-     * Tests if options() throws a runtime exception if a recursive mandatory option is missing
+     * Tests if optionsWithFallback()
      *
      * @dataProvider providerConfig
-     * @covers \Interop\Config\ConfigurationTrait::optionsWithFallback
-     * @covers \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     * @covers       \Interop\Config\ConfigurationTrait::optionsWithFallback
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
      */
     public function testOptionsWithFallback($config): void
     {
@@ -590,11 +598,100 @@ class ConfigurationTraitTest extends TestCase
         $stub->options($config, 'orm_default');
     }
 
+    /**
+     * Tests if options() works with an empty \ArrayAccess object and default options.
+     *
+     * @covers \Interop\Config\ConfigurationTrait::options
+     */
+    public function testEmptyArrayAccessWithDefaultOptions()
+    {
+        $stub = new ConnectionDefaultOptionsConfiguration();
+
+        $config = new \ArrayIterator([]);
+
+        $options = $stub->options($config);
+
+        self::assertCount(1, $options);
+        self::assertArrayHasKey('params', $options);
+
+        self::assertSame(
+            $options['params']['host'],
+            'awesomehost'
+        );
+        self::assertSame(
+            $options['params']['port'],
+            '4444'
+        );
+    }
+
+    /**
+     * Tests if options() works with iterable objects like \ArrayIterator or \ArrayObject
+     *
+     * @dataProvider providerConfigObjects
+     * @covers       \Interop\Config\ConfigurationTrait::options
+     * @covers       \Interop\Config\ConfigurationTrait::canRetrieveOptions
+     */
+    public function testOptionsWithObjects($config, $type): void
+    {
+        $stub = new UniversalContainerIdConfiguration($type);
+
+        self::assertTrue($stub->canRetrieveOptions($config, 'orm_default'));
+        $options = $stub->options($config, 'orm_default');
+
+        self::assertCount(2, $options);
+        self::assertArrayHasKey('driverClass', $options);
+        self::assertArrayHasKey('params', $options);
+
+        $driverClass = 'Doctrine\DBAL\Driver\PDOMySql\Driver';
+        $host = 'localhost';
+        $dbname = 'database';
+        $user = 'username';
+        $password = 'password';
+        $port = '4444';
+
+        if ($type !== UniversalContainerIdConfiguration::TYPE_ONLY_ITERATOR) {
+            $driverClass = $config['doctrine']['connection']['orm_default']['driverClass'];
+            $host = $config['doctrine']['connection']['orm_default']['params']['host'];
+            $dbname = $config['doctrine']['connection']['orm_default']['params']['dbname'];
+            $user = $config['doctrine']['connection']['orm_default']['params']['user'];
+            $password = $config['doctrine']['connection']['orm_default']['params']['password'];
+        }
+
+        self::assertSame($options['driverClass'], $driverClass);
+        self::assertSame($options['params']['host'], $host);
+        self::assertSame($options['params']['port'], $port);
+        self::assertSame($options['params']['dbname'], $dbname);
+        self::assertSame($options['params']['user'], $user);
+        self::assertSame($options['params']['password'], $password);
+    }
+
     public function providerConfig(): array
     {
         return [
             [$this->getTestConfig()],
             [new \ArrayObject($this->getTestConfig())],
+            [new \ArrayIterator($this->getTestConfig())],
+        ];
+    }
+
+    public function providerConfigObjects(): array
+    {
+        return [
+            [$this->getTestConfig(), UniversalContainerIdConfiguration::TYPE_ARRAY_ARRAY],
+            [new \ArrayObject($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_ARRAY],
+            [new \ArrayIterator($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_ARRAY],
+
+            [$this->getTestConfig(), UniversalContainerIdConfiguration::TYPE_ARRAY_OBJECT],
+            [new \ArrayObject($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_OBJECT],
+            [new \ArrayIterator($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_OBJECT],
+
+            [$this->getTestConfig(), UniversalContainerIdConfiguration::TYPE_ARRAY_ITERATOR],
+            [new \ArrayObject($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_ITERATOR],
+            [new \ArrayIterator($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ARRAY_ITERATOR],
+
+            [$this->getTestConfig(), UniversalContainerIdConfiguration::TYPE_ONLY_ITERATOR],
+            [new \ArrayObject($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ONLY_ITERATOR],
+            [new \ArrayIterator($this->getTestConfig()), UniversalContainerIdConfiguration::TYPE_ONLY_ITERATOR],
         ];
     }
 

--- a/test/TestAsset/ConnectionDefaultOptionsConfiguration.php
+++ b/test/TestAsset/ConnectionDefaultOptionsConfiguration.php
@@ -24,7 +24,7 @@ class ConnectionDefaultOptionsConfiguration implements RequiresConfig, ProvidesD
         return ['doctrine', 'connection'];
     }
 
-    public function defaultOptions(): array
+    public function defaultOptions(): iterable
     {
         return [
             'params' => [

--- a/test/TestAsset/ConnectionMandatoryRecursiveArrayIteratorContainerIdConfiguration.php
+++ b/test/TestAsset/ConnectionMandatoryRecursiveArrayIteratorContainerIdConfiguration.php
@@ -24,7 +24,7 @@ class ConnectionMandatoryRecursiveArrayIteratorContainerIdConfiguration implemen
      */
     public function dimensions(): iterable
     {
-        return ['doctrine', 'connection'];
+        return new \ArrayIterator(['doctrine', 'connection']);
     }
 
     /**
@@ -32,6 +32,6 @@ class ConnectionMandatoryRecursiveArrayIteratorContainerIdConfiguration implemen
      */
     public function mandatoryOptions(): iterable
     {
-        return ['params' => ['user', 'dbname'], 'driverClass'];
+        return new \ArrayIterator(['params' => ['user', 'dbname'], 'driverClass']);
     }
 }

--- a/test/TestAsset/OnlyIterator.php
+++ b/test/TestAsset/OnlyIterator.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Sandro Keil (https://sandro-keil.de)
+ *
+ * @link      http://github.com/sandrokeil/interop-config for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Sandro Keil
+ * @license   http://github.com/sandrokeil/interop-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace InteropTest\Config\TestAsset;
+
+
+class OnlyIterator implements \Iterator
+{
+    /**
+     * data
+     *
+     * @var array
+     */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function current()
+    {
+        return current($this->data);
+    }
+
+    public function next()
+    {
+        next($this->data);
+    }
+
+    public function key()
+    {
+        return key($this->data);
+    }
+
+    public function valid()
+    {
+        return current($this->data);
+    }
+
+    public function rewind()
+    {
+        reset($this->data);
+    }
+
+}

--- a/test/TestAsset/UniversalContainerIdConfiguration.php
+++ b/test/TestAsset/UniversalContainerIdConfiguration.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Sandro Keil (https://sandro-keil.de)
+ *
+ * @link      http://github.com/sandrokeil/interop-config for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Sandro Keil
+ * @license   http://github.com/sandrokeil/interop-config/blob/master/LICENSE.md New BSD License
+ */
+
+namespace InteropTest\Config\TestAsset;
+
+use Interop\Config\ConfigurationTrait;
+use Interop\Config\ProvidesDefaultOptions;
+use Interop\Config\RequiresConfigId;
+use Interop\Config\RequiresMandatoryOptions;
+
+class UniversalContainerIdConfiguration implements RequiresConfigId, ProvidesDefaultOptions, RequiresMandatoryOptions
+{
+    use ConfigurationTrait;
+
+    const TYPE_ARRAY_ITERATOR = 0;
+    const TYPE_ARRAY_OBJECT = 1;
+    const TYPE_ARRAY_ARRAY = 2;
+    const TYPE_ONLY_ITERATOR = 3;
+
+    private static $dimensions = [
+        'doctrine',
+        'universal',
+    ];
+
+    private static $mandatoryOptions = [
+        'params' => ['user', 'dbname'],
+        'driverClass',
+    ];
+
+    private static $defaultOptions = [
+        'params' => [
+            'host' => 'awesomehost',
+            'port' => '4444',
+        ],
+    ];
+
+    private $type;
+
+    public function __construct(int $type)
+    {
+        $this->type = $type;
+    }
+
+    public function dimensions(): iterable
+    {
+        return $this->getData('dimensions');
+    }
+
+    public function mandatoryOptions(): iterable
+    {
+        return $this->getData('mandatoryOptions');
+    }
+
+    public function defaultOptions(): iterable
+    {
+        return $this->getData('defaultOptions');
+    }
+
+    private function getData($name)
+    {
+        switch ($this->type) {
+            case self::TYPE_ARRAY_ITERATOR:
+                return new \ArrayIterator(self::$$name);
+                break;
+            case self::TYPE_ARRAY_OBJECT:
+                return new \ArrayObject(self::$$name);
+                break;
+            case self::TYPE_ONLY_ITERATOR:
+                return new OnlyIterator(self::$$name);
+                break;
+            case self::TYPE_ARRAY_ARRAY:
+            default:
+                return self::$$name;
+                break;
+        }
+    }
+}

--- a/test/testing.config.php.dist
+++ b/test/testing.config.php.dist
@@ -28,6 +28,20 @@ return [
                 ],
             ],
         ],
+        // package name
+        'universal' => [
+            // container id
+            'orm_default' => [
+                // mandatory params
+                'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+                'params' => [
+                    'host'     => 'localhost',
+                    'user'     => 'username',
+                    'password' => 'password',
+                    'dbname'   => 'database',
+                ],
+            ],
+        ],
     ],
     'one' => [
         'two' => [


### PR DESCRIPTION
Fixes #34 without BC break because return type `array` is still valid. Fixes also issues with only `\Iterator` classes.